### PR TITLE
Fix UPNP build script

### DIFF
--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -38,7 +38,7 @@ LIBS += \
 ifndef USE_UPNP
 	override USE_UPNP = -
 endif
-ifneq (${USE_UPNP}, -)
+ifneq (${USE_UPNP}, 0)
 	LIBS += -l miniupnpc
 	DEFS += -DUSE_UPNP=$(USE_UPNP)
 endif


### PR DESCRIPTION
`USE_UPNP` is set to `0` but is later checked against `-`. This patch makes the check against `0` so it's consistent.